### PR TITLE
Add redirect links for Airtable

### DIFF
--- a/apps/jubmoji-quest/next.config.js
+++ b/apps/jubmoji-quest/next.config.js
@@ -6,6 +6,22 @@ const nextConfig = {
     config.resolve.fallback = { fs: false, readline: false };
     return config;
   },
+  async redirects() {
+    return [
+      {
+        source: "/airtable",
+        destination:
+          "https://airtable.com/apprikYUs5WuXJRbN/tblEFhdjC2nEWP4cQ/viwFeEgb7Kfy08Jaa?blocks=hide",
+        permanent: true,
+      },
+      {
+        source: "/cardforyou",
+        destination:
+          "https://airtable.com/apprikYUs5WuXJRbN/shrep6Pp59ukNJp34/tblEFhdjC2nEWP4cQ",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Adds two new routes
- `airtable` which goes to an edit only link of airtable
- `cardforyou` which goes to a view only link