### PR TITLE
frontend validation for used leaderboard sigs

### DIFF
--- a/apps/jubmoji-quest/src/lib/localStorage.ts
+++ b/apps/jubmoji-quest/src/lib/localStorage.ts
@@ -80,6 +80,8 @@ export const addNullifiedSigs = async ({
 }: NullifiedSigs): Promise<void> => {
   const sigs = await loadNullifiedSigs();
 
+  console.log("adding nullfied sigs", questNullifiedSigs, sigs);
+
   Object.entries(questNullifiedSigs).forEach(([questId, newSigs]) => {
     if (!sigs.quests[Number(questId)]) {
       sigs.quests[Number(questId)] = newSigs;
@@ -90,6 +92,8 @@ export const addNullifiedSigs = async ({
     }
   });
 
+  console.log("sigs a", sigs);
+
   Object.entries(powerNullifiedSigs).forEach(([powerId, newSigs]) => {
     if (!sigs.powers[Number(powerId)]) {
       sigs.powers[Number(powerId)] = newSigs;
@@ -99,6 +103,8 @@ export const addNullifiedSigs = async ({
       );
     }
   });
+
+  console.log("sigs b", sigs);
 
   await writeNullifiedSigs(sigs);
 };

--- a/apps/jubmoji-quest/src/lib/localStorage.ts
+++ b/apps/jubmoji-quest/src/lib/localStorage.ts
@@ -84,10 +84,9 @@ export const addNullifiedSigs = async ({
     if (!sigs.quests[Number(questId)]) {
       sigs.quests[Number(questId)] = newSigs;
     } else {
-      sigs.quests[Number(questId)] = [
-        ...sigs.quests[Number(questId)],
-        ...newSigs,
-      ];
+      sigs.quests[Number(questId)] = Array.from(
+        new Set([...sigs.quests[Number(questId)], ...newSigs])
+      );
     }
   });
 
@@ -95,10 +94,9 @@ export const addNullifiedSigs = async ({
     if (!sigs.powers[Number(powerId)]) {
       sigs.powers[Number(powerId)] = newSigs;
     } else {
-      sigs.powers[Number(powerId)] = [
-        ...sigs.powers[Number(powerId)],
-        ...newSigs,
-      ];
+      sigs.powers[Number(powerId)] = Array.from(
+        new Set([...sigs.powers[Number(powerId)], ...newSigs])
+      );
     }
   });
 

--- a/apps/jubmoji-quest/src/lib/localStorage.ts
+++ b/apps/jubmoji-quest/src/lib/localStorage.ts
@@ -80,8 +80,6 @@ export const addNullifiedSigs = async ({
 }: NullifiedSigs): Promise<void> => {
   const sigs = await loadNullifiedSigs();
 
-  console.log("adding nullfied sigs", questNullifiedSigs, sigs);
-
   Object.entries(questNullifiedSigs).forEach(([questId, newSigs]) => {
     if (!sigs.quests[Number(questId)]) {
       sigs.quests[Number(questId)] = newSigs;
@@ -92,8 +90,6 @@ export const addNullifiedSigs = async ({
     }
   });
 
-  console.log("sigs a", sigs);
-
   Object.entries(powerNullifiedSigs).forEach(([powerId, newSigs]) => {
     if (!sigs.powers[Number(powerId)]) {
       sigs.powers[Number(powerId)] = newSigs;
@@ -103,8 +99,6 @@ export const addNullifiedSigs = async ({
       );
     }
   });
-
-  console.log("sigs b", sigs);
 
   await writeNullifiedSigs(sigs);
 };

--- a/apps/jubmoji-quest/src/lib/localStorage.ts
+++ b/apps/jubmoji-quest/src/lib/localStorage.ts
@@ -3,7 +3,7 @@ import {
   deserializeJubmojiList,
   serializeJubmojiList,
 } from "jubmoji-api";
-import { BackupState } from "../types";
+import { BackupState, NullifiedSigs } from "../types";
 
 export const loadJubmojis = async (): Promise<Jubmoji[]> => {
   const jubmojis = window.localStorage["jubmojis"];
@@ -73,3 +73,50 @@ export async function loadBackupState(): Promise<BackupState | undefined> {
 export async function saveBackupState(backup: BackupState): Promise<void> {
   window.localStorage["backup"] = JSON.stringify(backup);
 }
+
+export const addNullifiedSigs = async ({
+  quests: questNullifiedSigs,
+  powers: powerNullifiedSigs,
+}: NullifiedSigs): Promise<void> => {
+  const sigs = await loadNullifiedSigs();
+
+  Object.entries(questNullifiedSigs).forEach(([questId, newSigs]) => {
+    if (!sigs.quests[Number(questId)]) {
+      sigs.quests[Number(questId)] = newSigs;
+    } else {
+      sigs.quests[Number(questId)] = [
+        ...sigs.quests[Number(questId)],
+        ...newSigs,
+      ];
+    }
+  });
+
+  Object.entries(powerNullifiedSigs).forEach(([powerId, newSigs]) => {
+    if (!sigs.powers[Number(powerId)]) {
+      sigs.powers[Number(powerId)] = newSigs;
+    } else {
+      sigs.powers[Number(powerId)] = [
+        ...sigs.powers[Number(powerId)],
+        ...newSigs,
+      ];
+    }
+  });
+
+  await writeNullifiedSigs(sigs);
+};
+
+export const writeNullifiedSigs = async (
+  sigs: NullifiedSigs
+): Promise<void> => {
+  window.localStorage["nullifiedSigs"] = JSON.stringify(sigs);
+};
+
+export const loadNullifiedSigs = async (): Promise<NullifiedSigs> => {
+  const sigs = window.localStorage["nullifiedSigs"];
+
+  if (!sigs) {
+    return { quests: {}, powers: {} };
+  }
+
+  return JSON.parse(sigs);
+};

--- a/apps/jubmoji-quest/src/pages/quests/[id].tsx
+++ b/apps/jubmoji-quest/src/pages/quests/[id].tsx
@@ -71,7 +71,7 @@ export default function QuestDetailPage() {
     // User has no Jubmojis at all
     if (!jubmojis || jubmojis.length === 0) {
       return toast.error(
-        "Please collect some Jubmojis to update your team's score!"
+        "Please collect some Jubmojis to participate in this leaderboard!"
       );
     }
 
@@ -86,7 +86,7 @@ export default function QuestDetailPage() {
     );
     if (teamJubmojis.length === 0) {
       return toast.error(
-        "You must collect a team card Jubmoji to participate in the team leaderboard!"
+        "You must collect a team card Jubmoji to participate in this leaderboard!"
       );
     }
 

--- a/apps/jubmoji-quest/src/pages/quests/[id].tsx
+++ b/apps/jubmoji-quest/src/pages/quests/[id].tsx
@@ -77,8 +77,9 @@ export default function QuestDetailPage() {
     const { quests: questNullifiedSigMap } = await loadNullifiedSigs();
     const nullifiedSigs = questNullifiedSigMap[quest.id] || [];
 
-    const unnullifiedJubmojis =
-      jubmojis?.filter((jubmoji) => !nullifiedSigs.includes(jubmoji.sig)) || [];
+    const unnullifiedJubmojis = jubmojis.filter(
+      (jubmoji) => !nullifiedSigs.includes(jubmoji.sig)
+    );
     if (unnullifiedJubmojis.length === 0) {
       return toast.error(
         "All of your Jubmojis have already been submitted to the leaderboard!"
@@ -92,10 +93,11 @@ export default function QuestDetailPage() {
       }),
       {
         loading: "Updating team score...",
-        success: (score: any) => {
+        success: (scoreAdded: any) => {
           const collectionCardIndices = quest.collectionCards.map(
             (card) => card.index
           );
+          // Need to filter Jubmojis since we do not want to nullify team card signatures
           const nullifiedSigs = unnullifiedJubmojis
             .filter((jubmoji) =>
               collectionCardIndices.includes(jubmoji.pubKeyIndex)
@@ -107,10 +109,7 @@ export default function QuestDetailPage() {
             },
             powers: {},
           });
-          return (
-            `Added ${score} points to your team's score!` ||
-            "Team score updated!"
-          );
+          return `Added ${scoreAdded} points to your team's score!`;
         },
         error: (err: any) => err.message,
       }

--- a/apps/jubmoji-quest/src/types/index.ts
+++ b/apps/jubmoji-quest/src/types/index.ts
@@ -7,6 +7,11 @@ export interface BackupState {
   serialNum: string;
 }
 
+export interface NullifiedSigs {
+  quests: Record<number, string[]>; // questId -> nullified Jubmoji signatures
+  powers: Record<number, string[]>; // powerId -> nullified Jubmoji signatures
+}
+
 export type JubmojiCollectionCard = Card & {
   collectsFor: {
     id: number;


### PR DESCRIPTION
- [x] Defines a local storage type for storing quest and power nullifiers
- [x] Fetch used sigs and don't include in leaderboard proof
- [x] Update used sigs after successfully submitting a leaderboard proof  